### PR TITLE
Fix fan_in for weight initialization

### DIFF
--- a/train.py
+++ b/train.py
@@ -9,7 +9,7 @@ from einops import rearrange
 from common import GptConfig, encode, decode, train_data, val_data, lp_hyperparameters
 from model import GptLanguageModel
 
-remote = False 
+remote = True
 
 hyperparameters = GptConfig()
 


### PR DESCRIPTION
# What was the issue?
The distribution of the projection tensors for K, V, Q were scaled by the head dimension (`head_dim`) instead of the model dimension (`n_embd`). This was blowing up its variance.

# Change
- Switched `head_dim` to `n_embd` for `attention_kvq` to fix the tensor's std deviation
- Also noticed we were wasting some space by having an additional scale for each layer. This was not be used per layer so added out_scale for the final output before computing the logits.
- general styling improvements/comments clarifying whats happening 